### PR TITLE
build: better bundle support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "homepage": "https://nicedoc.io/microlinkhq/mql",
   "version": "0.5.10",
   "browser": "src/browser.js",
-  "main": "src/node.js",
+  "main": "src/index.js",
+  "module": "src/browser.js",
   "author": {
     "email": "josefrancisco.verdu@gmail.com",
     "name": "Kiko Beats",

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,1 @@
+module.exports = require(window ? './browser' : './node')


### PR DESCRIPTION
This PR aims to be possible to use the library across different environments (browser/Node.js) and transpilers (rollup, webpack, etc).

First of all, these are the fields on `package.json` relative with bundles:

```js
{
  "browser": "src/browser.js", // Browserify
  "main": "src/node.js", // CommonJS / Node.js
  "umd:main": "dist/mql.js", // ES Modules
  "unpkg": "dist/mql.js" // unpkg.com
}
```

That doesn't change too much; However, this PR is introducing a dynamic checker, just to be sure your environment expectations are right:

```js
module.exports = require(window ? './browser' : './node')
```

That's mainly aimed because I noted `jest`, although is a test runner widely used for browser side, it tries to load `main` by default.

if you want to load `browser` bundle, you need to use `--browser` flag, but under this module, it doesn't understand ES modules code 😭.

So the dynamic checker is the only way to be sure the file is loading is the file it needs. You need to read `window` as `isBrowser()`, and I considered this checker implementation because it is a rare thing to have a `window` available on global scope at Node.js (that a not true condition at https://deno.land).