### PR TITLE
feat: add types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,120 +1,138 @@
 /// <reference types="node" />
 
-declare module '@microlink/mql' {
-  export type WaitUntilEvent =
-    | 'load'
-    | 'domcontentloaded'
-    | 'networkidle0'
-    | 'networkidle2'
+declare module "@microlink/mql" {
+  export type WaitUntilEvent = "load" | "domcontentloaded" | "networkidle0" | "networkidle2";
 
   export type ScreenshotOptions = Partial<{
-    background: string
-    browser: 'light' | 'dark'
-    click: string | string[]
-    deviceScaleFactor: number
-    disableAnimations: boolean
-    emulation: string
-    fullPage: boolean
-    hasTouch: boolean
-    height: number
-    hide: string | string[]
-    isLandscape: boolean
-    isMobile: boolean
-    scrollTo: string
-    type: 'jpeg' | 'png'
-    waitFor: number | string
-    waitUntil: WaitUntilEvent | WaitUntilEvent[]
-    width: number
-  }>
+    background: string;
+    browser: "light" | "dark";
+    click: string | string[];
+    deviceScaleFactor: number;
+    disableAnimations: boolean;
+    emulation: string;
+    fullPage: boolean;
+    hasTouch: boolean;
+    height: number;
+    hide: string | string[];
+    isLandscape: boolean;
+    isMobile: boolean;
+    scrollTo: string;
+    type: "jpeg" | "png";
+    waitFor: number | string;
+    waitUntil: WaitUntilEvent | WaitUntilEvent[];
+    width: number;
+  }>;
 
   export type MqlQueryResponseType =
-    | 'author'
-    | 'date'
-    | 'description'
-    | 'image'
-    | 'title'
-    | 'url'
-    | 'lang'
-    | 'publisher'
+    | "author"
+    | "date"
+    | "description"
+    | "image"
+    | "title"
+    | "url"
+    | "lang"
+    | "publisher";
 
   export type MqlQueryOptions = Partial<{
-    attr: string | string[]
-    selector: string | string[]
-    selectorAll: string | string[]
-    type: MqlQueryResponseType
-  }>
+    attr: string | string[];
+    selector: string | string[];
+    selectorAll: string | string[];
+    type: MqlQueryResponseType;
+  }>;
 
   export interface MqlQuery {
-    [field: string]: MqlQueryOptions
+    [field: string]: MqlQueryOptions;
   }
 
   export type MicrolinkApiOptions = Partial<{
-    audio: boolean
-    data: MqlQuery
-    embed: string
-    filter: string
-    force: boolean
-    headers: object
-    meta: boolean
-    palette: boolean
-    prerender: boolean | 'auto'
-    proxy: string
-    screenshot: boolean | ScreenshotOptions
-    ttl: string | number
-    url: string
-    video: boolean
-  }>
+    animations: boolean;
+    audio: boolean;
+    click: string | string[];
+    colorScheme: "dark" | "light";
+    codeScheme: string;
+    data: MqlQuery;
+    device: string;
+    embed: string;
+    filter: string;
+    force: boolean;
+    headers: object;
+    hide: string | string[];
+    iframe: boolean | object;
+    insights: boolean | object;
+    javascript: boolean;
+    mediatype: string;
+    meta: boolean;
+    modules: string | string[];
+    palette: boolean;
+    ping: boolean | object;
+    prerender: boolean | "auto";
+    proxy: string;
+    remove: string | string[];
+    retry: number;
+    screenshot: boolean | ScreenshotOptions;
+    scripts: string | string[];
+    scroll: string;
+    styles: string | string[];
+    timeout: number;
+    ttl: string | number;
+    url: string;
+    video: boolean;
+    viewport: object;
+    waitForSelector: string;
+    waitForTimeout: number;
+    waitUntil: string | string[];
+  }>;
 
   export type MqlOptions = Partial<{
-    apiKey: string
-    retry: number
-    cache: Map<string, any>
-    timeout: number
-  }>
+    apiKey: string;
+    retry: number;
+    cache: Map<string, any>;
+    timeout: number;
+  }>;
 
   export interface ImageInfo {
-    width: number
-    height: number
-    type: string
-    url: string
-    size: number
-    size_pretty: string
+    width: number;
+    height: number;
+    type: string;
+    url: string;
+    size: number;
+    size_pretty: string;
   }
 
   export interface PlayableMediaInfo extends ImageInfo {
-    duration: number
-    duration_pretty: string
+    duration: number;
+    duration_pretty: string;
   }
 
   export type MqlResponseData = Partial<{
-    author: string
-    date: string
-    description: string
-    video: string
-    lang: string
-    publisher: string
-    title: string
-    url: string
-    image: ImageInfo
-    screenshot: ImageInfo
-    logo: ImageInfo
-    video: PlayableMediaInfo
-    audio: PlayableMediaInfo
-  }>
+    author: string;
+    date: string;
+    description: string;
+    video: string;
+    lang: string;
+    publisher: string;
+    title: string;
+    url: string;
+    image: ImageInfo;
+    screenshot: ImageInfo;
+    logo: ImageInfo;
+    video: PlayableMediaInfo;
+    audio: PlayableMediaInfo;
+  }>;
 
-  export type MqlStatus = 'success' | 'fail'
+  export type MqlStatus = "success" | "fail";
 
   export interface MqlResponse {
-    status: MqlStatus
-    data: MqlResponseData
-    response: Response
+    status: MqlStatus;
+    data: MqlResponseData;
+    response: Response;
   }
 
-  declare function mql(url: string, opts?: MqlOptions & MicrolinkApiOptions): Promise<MqlResponse>
+  declare function mql(url: string, opts?: MqlOptions & MicrolinkApiOptions): Promise<MqlResponse>;
 
   declare namespace mql {
     export class MicrolinkError extends Error {}
   }
 
-  export = mql
+  export = mql;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,120 @@
+/// <reference types="node" />
+
+declare module '@microlink/mql' {
+  export type WaitUntilEvent =
+    | 'load'
+    | 'domcontentloaded'
+    | 'networkidle0'
+    | 'networkidle2'
+
+  export type ScreenshotOptions = Partial<{
+    background: string
+    browser: 'light' | 'dark'
+    click: string | string[]
+    deviceScaleFactor: number
+    disableAnimations: boolean
+    emulation: string
+    fullPage: boolean
+    hasTouch: boolean
+    height: number
+    hide: string | string[]
+    isLandscape: boolean
+    isMobile: boolean
+    scrollTo: string
+    type: 'jpeg' | 'png'
+    waitFor: number | string
+    waitUntil: WaitUntilEvent | WaitUntilEvent[]
+    width: number
+  }>
+
+  export type MqlQueryResponseType =
+    | 'author'
+    | 'date'
+    | 'description'
+    | 'image'
+    | 'title'
+    | 'url'
+    | 'lang'
+    | 'publisher'
+
+  export type MqlQueryOptions = Partial<{
+    attr: string | string[]
+    selector: string | string[]
+    selectorAll: string | string[]
+    type: MqlQueryResponseType
+  }>
+
+  export interface MqlQuery {
+    [field: string]: MqlQueryOptions
+  }
+
+  export type MicrolinkApiOptions = Partial<{
+    audio: boolean
+    data: MqlQuery
+    embed: string
+    filter: string
+    force: boolean
+    headers: object
+    meta: boolean
+    palette: boolean
+    prerender: boolean | 'auto'
+    proxy: string
+    screenshot: boolean | ScreenshotOptions
+    ttl: string | number
+    url: string
+    video: boolean
+  }>
+
+  export type MqlOptions = Partial<{
+    apiKey: string
+    retry: number
+    cache: Map<string, any>
+    timeout: number
+  }>
+
+  export interface ImageInfo {
+    width: number
+    height: number
+    type: string
+    url: string
+    size: number
+    size_pretty: string
+  }
+
+  export interface PlayableMediaInfo extends ImageInfo {
+    duration: number
+    duration_pretty: string
+  }
+
+  export type MqlResponseData = Partial<{
+    author: string
+    date: string
+    description: string
+    video: string
+    lang: string
+    publisher: string
+    title: string
+    url: string
+    image: ImageInfo
+    screenshot: ImageInfo
+    logo: ImageInfo
+    video: PlayableMediaInfo
+    audio: PlayableMediaInfo
+  }>
+
+  export type MqlStatus = 'success' | 'fail'
+
+  export interface MqlResponse {
+    status: MqlStatus
+    data: MqlResponseData
+    response: Response
+  }
+
+  declare function mql(url: string, opts?: MqlOptions & MicrolinkApiOptions): Promise<MqlResponse>
+
+  declare namespace mql {
+    export class MicrolinkError extends Error {}
+  }
+
+  export = mql
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.9.5",
   "browser": "src/browser.js",
   "main": "src/node.js",
+  "types": "index.d.ts",
   "author": {
     "email": "josefrancisco.verdu@gmail.com",
     "name": "Kiko Beats",


### PR DESCRIPTION
Added initial types (`index.d.ts`) file based on the issue https://github.com/microlinkhq/mql/issues/25 by @lachenmayer. 

Since his posting obviously a bit has changed, however, and I added the screenshot / url fields to the `MqlResponseData` and `ImageInfo` interfaces respectively.

I'm only familiar with the screenshot portion of microlink, so if anyone else can look over some of the other fields / response shapes to confirm they're still up-to-date and correct, that'd be awesome!

**EDIT**: Went through and fleshed out all the new API parameter types here.

With this change one can now `import mql from '@microlink/mql` in Typescript  projects :+1: 