### PR TITLE
include index.d.ts in files

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   "files": [
     "dist",
     "lightweight.js",
+    "index.d.ts",
     "src"
   ],
   "scripts": {


### PR DESCRIPTION
The type declarations weren't included in the npm package because index.d.ts wasn't part of the `files` property in the `package.json`. This should fix it.