### PR TITLE
fix: avoid class field declaration

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -8,9 +8,9 @@ const factory = require('./factory')
 const { default: ky } = require('./ky')
 
 class MicrolinkError extends Error {
-  name = 'MicrolinkError'
   constructor (props) {
     super()
+    this.name = 'MicrolinkError'
     Object.assign(this, props)
     this.description = this.message
     this.message = this.code


### PR DESCRIPTION
Although Class field declarations for JavaScript is stage-4, the browser support is still poor.

related: https://kangax.github.io/compat-table/es2016plus/
demo: https://es6console.com/lafkpuz2/